### PR TITLE
Add "domino placement" example

### DIFF
--- a/examples/Domino.hs
+++ b/examples/Domino.hs
@@ -5,7 +5,7 @@ pieces?
 Usage: ./Domino 4 3
    or: ghci> prettySolve 4 3
 -}
-module Domino where
+module Main where
 
 import Control.Monad (guard)
 import System.Environment (getArgs)

--- a/examples/Domino.hs
+++ b/examples/Domino.hs
@@ -3,6 +3,7 @@ In how many ways can a n x m board be entirely covered by 2 x 1 domino
 pieces?
 
 Usage: ./Domino 4 3
+       time stack runghc examples/Domino.hs 4 9
    or: ghci> prettySolve 4 3
 -}
 module Main where

--- a/examples/Domino.hs
+++ b/examples/Domino.hs
@@ -1,0 +1,83 @@
+{-
+In how many ways can a n x m board be entirely covered by 2 x 1 domino
+pieces?
+-}
+module Domino where
+
+import Control.Monad (guard)
+import System.Environment (getArgs)
+import qualified Data.Set
+
+import qualified OBDD
+
+dominoes h w = rows ++ cols
+    where rows = positions [1..h-1] [1..w] $ \x y -> ((x, y), (x+1, y))
+          cols = positions [1..h] [1..w-1] $ \x y -> ((x, y), (x, y+1))
+          positions xs ys f = do
+            x <- xs
+            y <- ys
+            return (f x y)
+
+positions h w = do
+    x <- [1..h]
+    y <- [1..w]
+    return (x, y)
+
+dominoFormula h w = OBDD.and [ everyPosCovered, noPosCoveredTwice ]
+    where everyPosCovered = OBDD.and $ do
+                                -- forall fields f \in F
+                                f <- fields
+                                return $ OBDD.or $ do
+                                -- forall placements of pieces p \in P
+                                    p <- placements
+                                    return $ OBDD.and [
+                                        OBDD.unit p True,                 -- placement is chosen
+                                        OBDD.constant (f `isCoveredBy` p) -- f is covered by placement p
+                                     ]
+          noPosCoveredTwice = OBDD.and $ do
+                                  f <- fields
+                                  return $ OBDD.not $ OBDD.or $ do
+                                      p <- placements
+                                      return $ OBDD.or $ do
+                                          q <- placements
+                                          guard $ p /= q
+                                          return $ OBDD.and [
+                                              OBDD.unit p True,
+                                              OBDD.constant (f `isCoveredBy` p),
+
+                                              OBDD.unit q True,
+                                              OBDD.constant (f `isCoveredBy` q)
+                                           ]
+          fields = positions h w
+          placements = dominoes h w
+          f `isCoveredBy` p = f == fst p || f == snd p
+
+printPos h w pos = putStr $ concat $ do
+    x <- [1..h]
+    y <- [1..w]
+    let l = if (x, y) == pos
+            then "x"
+            else "."
+    return $ if y == w
+             then l ++ "\n"
+             else l
+
+printPositions h w ps = putStr $ concat $ do
+    x <- [1..h]
+    y <- [1..w]
+    let l = if any (== (x, y)) ps
+            then "x"
+            else "."
+    return $ if y == w
+             then l ++ "\n"
+             else l
+
+printDominoes h w ds = printPositions h w $ concat $ map (\(p, q) -> [p, q]) ds
+
+main = do
+    args <- getArgs
+    let [width, height] = case map read args :: [Int] of
+              [] -> [3, 4]
+              [width, height] -> [width, height]
+    print $ OBDD.number_of_models (Data.Set.fromList $ dominoes height width)
+          $ dominoFormula height width

--- a/examples/Domino.hs
+++ b/examples/Domino.hs
@@ -1,6 +1,9 @@
 {-
 In how many ways can a n x m board be entirely covered by 2 x 1 domino
 pieces?
+
+Usage: ./Domino 4 3
+   or: ghci> prettySolve 4 3
 -}
 module Domino where
 

--- a/examples/Domino.hs
+++ b/examples/Domino.hs
@@ -11,7 +11,7 @@ module Main where
 
 import Control.Monad (guard, when)
 import Data.Maybe (isJust)
-import System.Environment (getArgs, getEnvironment)
+import System.Environment (getArgs, lookupEnv)
 import qualified Data.Map
 import qualified Data.Set
 
@@ -86,7 +86,7 @@ main = do
               [] -> [4, 3]
               [width, height] -> [width, height]
     let formula = dominoFormula width height
-    verbose <- getEnvironment >>= \env -> return $ isJust $ lookup "VERBOSE" env
+    verbose <- lookupEnv "VERBOSE" >>= return . isJust
     when verbose $ mapM_ (\ds -> prettySolution width height ds >> putStrLn "")
                    . map (map fst . filter snd)
                    . map (Data.Map.toList) $

--- a/examples/Domino.hs
+++ b/examples/Domino.hs
@@ -4,12 +4,14 @@ pieces?
 
 Usage: ./Domino 4 3
        time stack runghc examples/Domino.hs 4 9
+       VERBOSE=1 stack runghc examples/Domino.hs 2 3
    or: ghci> prettySolve 4 3
 -}
 module Main where
 
-import Control.Monad (guard)
-import System.Environment (getArgs)
+import Control.Monad (guard, when)
+import Data.Maybe (isJust)
+import System.Environment (getArgs, getEnvironment)
 import qualified Data.Map
 import qualified Data.Set
 
@@ -84,8 +86,9 @@ main = do
               [] -> [4, 3]
               [width, height] -> [width, height]
     let formula = dominoFormula width height
-    mapM_ (\ds -> prettySolution width height ds >> putStrLn "")
-        . map (map fst . filter snd)
-        . map (Data.Map.toList) $
-        OBDD.models (Data.Set.fromList $ dominoes width height) formula
+    verbose <- getEnvironment >>= \env -> return $ isJust $ lookup "VERBOSE" env
+    when verbose $ mapM_ (\ds -> prettySolution width height ds >> putStrLn "")
+                   . map (map fst . filter snd)
+                   . map (Data.Map.toList) $
+                   OBDD.models (Data.Set.fromList $ dominoes width height) formula
     print $ OBDD.number_of_models (Data.Set.fromList $ dominoes width height) formula

--- a/obdd.cabal
+++ b/obdd.cabal
@@ -50,6 +50,12 @@ test-suite obdd-placement
     Main-Is: Placement.hs
     Build-Depends: base, containers, obdd
 
+test-suite obdd-domino
+    Hs-Source-Dirs: examples
+    Type: exitcode-stdio-1.0
+    Main-Is: Domino.hs
+    Build-Depends: base, containers, obdd
+
 test-suite obdd-cubism
     Hs-Source-Dirs : examples
     Type: exitcode-stdio-1.0


### PR DESCRIPTION
This is a solution for the "domino placement" problem:

> In how many ways can a n x m board be entirely covered by 2 x 1 domino pieces?

Here's a short performance test, the numbers match the results from [[1]][read.pdf]:

```bash
lu ~/r/jw/haskell-obdd$ time stack runghc examples/Domino.hs 4 9
6336

real	0m1.778s
user	0m1.730s
sys	0m0.110s
lu ~/r/jw/haskell-obdd$ time stack runghc examples/Domino.hs 6 9
817991

real	0m4.234s
user	0m4.181s
sys	0m0.126s
lu ~/r/jw/haskell-obdd$ time stack runghc examples/Domino.hs 8 9
108435745

real	0m9.510s
user	0m9.425s
sys	0m0.156s
lu ~/r/jw/haskell-obdd$ time stack runghc examples/Domino.hs 10 9
14479521761

real	0m20.905s
user	0m20.777s
sys	0m0.201s
lu ~/r/jw/haskell-obdd$ time stack runghc examples/Domino.hs 12 9
1937528668711

real	0m49.473s
user	0m49.086s
sys	0m0.466s
```

(Run on my laptop, with an "Intel(R) Core(TM) i5-3320M CPU @ 2.60GHz" processor.)

[read.pdf]: https://www.fq.math.ca/Scanned/18-1/read.pdf